### PR TITLE
use path.join for relativeFilePath

### DIFF
--- a/src/getSvgContents.js
+++ b/src/getSvgContents.js
@@ -40,7 +40,7 @@ class GetSVGContents {
       throw new Error('eleventy-plugin-svg-contents requires a filetype of svg');
     }
 
-    const relativeFilePath = `.${this.file}`;
+    const relativeFilePath = path.join('.', this.file);
 
     const data = fs.readFileSync(relativeFilePath, (err, contents) => {
       if (err) {


### PR DESCRIPTION
The current method of getting a relative file path results in some wacky behavior. Taking an example from the docs...

```nunjucks
{{ 'path/to/file.svg' | svgContents }} <!-- looks in ./.path/to/file.svg -->
{{ '/path/to/file.svg' | svgContents }} <!-- looks in ./path/to/file.svg -->
{{ './path/to/file.svg' | svgContents }} <!-- looks in ../path/to/file.svg -->
```
That means that the user actually needs to write an _absolute_ file path in order to get a relative file path. Using `path.join` solves this:

```nunjucks
{{ 'path/to/file.svg' | svgContents }} <!-- looks in ./path/to/file.svg -->
{{ '/path/to/file.svg' | svgContents }} <!-- looks in ./path/to/file.svg -->
{{ './path/to/file.svg' | svgContents }} <!-- looks in ./path/to/file.svg -->
```